### PR TITLE
Migrate dagger from the deprecated v1 to the new Google v2

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -248,9 +248,9 @@ publishing {
 
 dependencies {
     //compile fileTree(dir: 'libs', include: ['*.jar'])
-    compileOnly 'com.squareup.dagger:dagger-compiler:1.2.2'
-    kapt 'com.squareup.dagger:dagger-compiler:1.2.2'
-    annotationProcessor 'com.squareup.dagger:dagger-compiler:1.2.2'
+    compileOnly 'com.google.dagger:dagger-compiler:2.22.1'
+    kapt 'com.google.dagger:dagger-compiler:2.22.1'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.22.1'
 
     implementation('com.ciscowebex:androidsdk_commlib:2.0.0@aar', {
         transitive = true


### PR DESCRIPTION
We use Dagger2 in our project and are having major difficulties using the WebX SDK while it depends on Dagger v1. Dagger v1 was deprecated 3-4 years ago so it is time for an upgrade.