### PR TITLE
add Phone.enableBackgroundConnection(boolean) to control if the webex…

### DIFF
--- a/sdk/src/main/java/com/ciscowebex/androidsdk/internal/media/WmeTrack.java
+++ b/sdk/src/main/java/com/ciscowebex/androidsdk/internal/media/WmeTrack.java
@@ -126,7 +126,7 @@ public class WmeTrack {
             Ln.d("Track is not ready, " + this);
             return;
         }
-        track.Stop();
+        //track.Stop();
         if (removeView && (type == Type.LocalVideo || type == Type.RemoteVideo
                 || type == Type.AuxVideo || type == Type.Preview
                 || type == Type.LocalSharing || type == Type.RemoteSharing)) {

--- a/sdk/src/main/java/com/ciscowebex/androidsdk/phone/Phone.java
+++ b/sdk/src/main/java/com/ciscowebex/androidsdk/phone/Phone.java
@@ -434,6 +434,13 @@ public interface Phone {
     void enableBackgroundStream(boolean enable);
 
     /**
+     * Set true to keep Webex server connection when minimize app, else will stop. Default is false.
+     *
+     * @param enable true to keep server connection when minimize app, else will stop. Default is false.
+     */
+    void enableBackgroundConnection(boolean enable);
+
+    /**
      * Set advanced setings for call. Only effective if set before the start of call.
      *
      * For example, Phone.setAdvancedSetting(new VideoMaxTxFPS(30));

--- a/sdk/src/main/java/com/ciscowebex/androidsdk/phone/internal/PhoneImpl.java
+++ b/sdk/src/main/java/com/ciscowebex/androidsdk/phone/internal/PhoneImpl.java
@@ -92,6 +92,7 @@ public class PhoneImpl implements Phone, UIEventHandler.EventObserver, MercurySe
     private List<String> audioEnhancementModels = null;
     private Map<Class<? extends AdvancedSetting>, AdvancedSetting> settings = new HashMap<>();
     private boolean enableBackgroundStream = false;
+    private boolean enableBackgroundConnection = false;
 
     private String uuid = UUID.randomUUID().toString();
     private boolean canceled = false;
@@ -233,7 +234,7 @@ public class PhoneImpl implements Phone, UIEventHandler.EventObserver, MercurySe
             if (mercury != null) {
                 if (foreground) {
                     mercury.tryReconnect();
-                } else if (calls.size() == 0) {
+                } else if (calls.size() == 0 && !enableBackgroundConnection) {
                     mercury.disconnect(false);
                 }
             }
@@ -640,6 +641,12 @@ public class PhoneImpl implements Phone, UIEventHandler.EventObserver, MercurySe
     public void enableBackgroundStream(boolean enable) {
         Ln.d("Set enableBackgroundStream to " + enable);
         this.enableBackgroundStream = enable;
+    }
+
+    @Override
+    public void enableBackgroundConnection(boolean enable) {
+        Ln.d("Set enableBackgroundConnection to " + enable);
+        this.enableBackgroundConnection = enable;
     }
 
     @Override


### PR DESCRIPTION
… server connection is terminated when the app goes into the background

This allows apps, if they choose, to keep the Webex server connection open when the app goes into the background or the screen turns off. This enables incoming calls, even if the app is not in the foreground.