### PR TITLE
send moderator and pin values to the server

### DIFF
--- a/sdk/src/main/java/com/ciscowebex/androidsdk/phone/internal/CallService.java
+++ b/sdk/src/main/java/com/ciscowebex/androidsdk/phone/internal/CallService.java
@@ -343,18 +343,13 @@ public class CallService {
         json.put("device", device.toJsonMap(Device.Type.WEB_CLIENT.getTypeName()));
         json.put("respOnlySdp", true);
         json.put("correlationId", correlationId);
-        if (callee == null) {
-            if (option.isModerator()) {
-                json.put("moderator", true);
-            }
-            if (option.getPin() != null) {
-                json.put("pin", option.getPin());
-            }
+        json.put("moderator", option.isModerator());
+        if (option.getPin() != null) {
+            json.put("pin", option.getPin());
         }
-        else {
+        if (callee != null) {
             json.put("invitee", Maps.makeMap("address", callee));
             json.put("supportsNativeLobby", true);
-            json.put("moderator", false);
         }
         return json;
     }


### PR DESCRIPTION
Host keys and meeting passwords specified via MediaOption.setPin() don't work because of two issues in CallService.makeBody().

The first issue is that moderator and pin are only set in the request json if callee is null. In the case of trying to join a meeting by meeting ID, callee is the meeting ID and it's non-null, so the pin will never get set.

The second issue is that the moderator flag is only sent to the server if it's true. However if it's false, it also needs to be sent to the server, otherwise the server ignores the pin field.

This change fixes both issues. 