### PR TITLE
Allow membership updates about external members

### DIFF
--- a/sdk/src/main/java/com/ciscowebex/androidsdk/internal/model/LocusParticipantModel.java
+++ b/sdk/src/main/java/com/ciscowebex/androidsdk/internal/model/LocusParticipantModel.java
@@ -266,8 +266,7 @@ public class LocusParticipantModel {
     }
 
     public boolean isValidCiUser() {
-        return (getType() == LocusParticipantModel.Type.USER && !getPerson().isExternal()) ||
-                getType() == LocusParticipantModel.Type.RESOURCE_ROOM;
+        return getType() == LocusParticipantModel.Type.USER || getType() == LocusParticipantModel.Type.RESOURCE_ROOM;
     }
 
     public boolean isUserOrResourceRoom() {


### PR DESCRIPTION
In order to have membership information about dial-in and members connected through SIP we need to skip "!getPerson().isExternal()" check for user validation.

Related space - SPARK-201708